### PR TITLE
Make headers stick to flex-start (top)

### DIFF
--- a/app/src/assets/css/CommitteeInfo.css
+++ b/app/src/assets/css/CommitteeInfo.css
@@ -1,6 +1,7 @@
 .container {
   display: flex;
   flex-direction: column;
+  align-self: flex-start;
   width: 24rem;
   border-style: solid;
   border: 2px;


### PR DESCRIPTION
Stops headers from floating centered when opening another header

## Before
### One open
![image](https://user-images.githubusercontent.com/5422571/29458981-099b2b96-8422-11e7-8549-032bb9fc5809.png)

### Multiple open
![image](https://user-images.githubusercontent.com/5422571/29459023-3a0d0d8a-8422-11e7-98fa-b33d26362dfa.png)

## After
### One open
![image](https://user-images.githubusercontent.com/5422571/29458968-f826322a-8421-11e7-85e4-61e289c4eb53.png)

### Multiple open
![image](https://user-images.githubusercontent.com/5422571/29459008-28e4bfbc-8422-11e7-82a9-9309fa29d53f.png)

