### PR TITLE
Setting height on icons as some browsers require a defined height

### DIFF
--- a/app/src/assets/css/CommitteeInfo.css
+++ b/app/src/assets/css/CommitteeInfo.css
@@ -11,7 +11,7 @@
 
 .header {
   box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.2);
-  flex: 1;
+  flex: 1 0 auto;
   background: #ffffff;
   border: 0.1rem solid #ffffff;
   padding: 0.5rem;

--- a/app/src/assets/css/CommitteeInfo.css
+++ b/app/src/assets/css/CommitteeInfo.css
@@ -51,7 +51,7 @@
 .img {
   padding-top: 0.5rem;
   width: 2.5rem;
-  height: inherit;
+  height: 3.75rem;
   display: inline-block;
 }
 


### PR DESCRIPTION
Fixes both Edge and Safari, where Edge did not display SVG icons on the front page because IE/Edge interprets undefined as 0. Safari also has the same problem but they are using the inbuilt size defined in the SVG as default instead.