### PR TITLE
Define height attribute for SVGs also [safari fix]

### DIFF
--- a/app/src/assets/css/CommitteeInfo.css
+++ b/app/src/assets/css/CommitteeInfo.css
@@ -51,7 +51,7 @@
 .img {
   padding-top: 0.5rem;
   width: 2.5rem;
-  height: inherit;
+  height: 3.5rem;
   display: inline-block;
 }
 


### PR DESCRIPTION
### Safari before
![safari-1](https://user-images.githubusercontent.com/5422571/29487603-5f770df2-84fc-11e7-929b-c2549704e3a9.png)

### Safari after
![safari-2](https://user-images.githubusercontent.com/5422571/29487604-5f77839a-84fc-11e7-83d0-90b46c927f39.png)

### Chrome before
![chrome-1](https://user-images.githubusercontent.com/5422571/29487602-5f5bc862-84fc-11e7-8a6a-e6583199cf89.png)

### Chrome after
![chrome-2](https://user-images.githubusercontent.com/5422571/29487601-5f5b7236-84fc-11e7-8f4d-2353cb065341.png)
