### PR TITLE
Wrap button content in div to support flex [safari fix]

### DIFF
--- a/app/src/__tests__/__snapshots__/Routes.js.snap
+++ b/app/src/__tests__/__snapshots__/Routes.js.snap
@@ -513,7 +513,11 @@ exports[`ConnectedRoutes renders mounted root route 1`] = `
                                     <button
                                       className="button"
                                     >
-                                      Gå til søknad
+                                      <div
+                                        className="buttonContent"
+                                      >
+                                        Gå til søknad
+                                      </div>
                                     </button>
                                   </Button>
                                 </a>

--- a/app/src/assets/css/Button.css
+++ b/app/src/assets/css/Button.css
@@ -11,10 +11,14 @@
   text-transform: uppercase;
   font-weight: bold;
   font-size: 1.5rem;
+  transition: 0.2s;
+  display: block;
+}
+
+.buttonContent {
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: 0.2s;
 }
 
 .button:hover {

--- a/app/src/components/Button.jsx
+++ b/app/src/components/Button.jsx
@@ -6,9 +6,11 @@ import _s from 'assets/css/Button.css';
 function Button({ children, onClick, text, iconLeft, iconRight, disabled }) {
   return(
     <button className={_s.button} onClick={onClick} disabled={disabled}>
+      <div className={_s.buttonContent}>
       { iconLeft && <img className={_s.iconLeft} src={iconLeft} /> }
       { text }
       { iconRight && <img className={_s.iconRight} src={iconRight} /> }
+      </div>
     </button>
   )
 }

--- a/app/src/components/__tests__/__snapshots__/Button.js.snap
+++ b/app/src/components/__tests__/__snapshots__/Button.js.snap
@@ -3,18 +3,26 @@
 exports[`button renders correctly 1`] = `
 <button
   className="button"
-/>
+>
+  <div
+    className="buttonContent"
+  />
+</button>
 `;
 
 exports[`button renders correctly with icon 1`] = `
 <button
   className="button"
 >
-  <img
-    className="iconLeft"
-    src="icon.png"
-  />
-  Button with icon
+  <div
+    className="buttonContent"
+  >
+    <img
+      className="iconLeft"
+      src="icon.png"
+    />
+    Button with icon
+  </div>
 </button>
 `;
 
@@ -22,11 +30,15 @@ exports[`button renders correctly with right icon 1`] = `
 <button
   className="button"
 >
-  Button with icon right
-  <img
-    className="iconRight"
-    src="icon2.png"
-  />
+  <div
+    className="buttonContent"
+  >
+    Button with icon right
+    <img
+      className="iconRight"
+      src="icon2.png"
+    />
+  </div>
 </button>
 `;
 
@@ -34,6 +46,10 @@ exports[`button renders correctly with text 1`] = `
 <button
   className="button"
 >
-  Button with text
+  <div
+    className="buttonContent"
+  >
+    Button with text
+  </div>
 </button>
 `;


### PR DESCRIPTION
Mostly a safari fix, but `display: flex` on buttons, in general, is a bit flaky.

### Safari before
![screenshot 2017-08-19 15 41 56](https://user-images.githubusercontent.com/5422571/29487633-e011e5a4-84fc-11e7-87f3-c3e2d6092032.png)

### Safari after
![screenshot 2017-08-19 16 34 30](https://user-images.githubusercontent.com/5422571/29487635-e308a892-84fc-11e7-8f30-f287ab345224.png)


Other browsers look the same.